### PR TITLE
remove old 89 -> 256 color conversion LBM

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -710,18 +710,4 @@ minetest.register_lbm({
 	end
 })
 
-minetest.register_lbm({
-	name = "blox:recolor_stuff",
-	label = "Convert 89-color blocks to use UD extended palette",
-	run_at_every_load = false,
-	nodenames = blox.old_89_color_nodes,
-	action = function(pos, node)
-		local meta = minetest.get_meta(pos)
-		if meta:get_string("palette") ~= "ext" then
-			minetest.swap_node(pos, { name = node.name, param2 = unifieddyes.convert_classic_palette[node.param2] })
-			meta:set_string("palette", "ext")
-		end
-	end
-})
-
 print("Blox Mod [" ..version.. "] Loaded!")

--- a/init.lua
+++ b/init.lua
@@ -693,7 +693,7 @@ minetest.register_lbm({
 		if color == "purple" then
 			color = "violet"
 		elseif color == "blue" then
-			color = "skyblue"
+			color = "azure"
 		elseif color == "pink" then
 			color = "magenta"
 		elseif color == "black" and


### PR DESCRIPTION
It's done its job by now, and anyway UD doesn't support the old 89-color palette anymore (obsolete), except in split mode (irreplacable), so that LBM can't run anyway.  At worse, this may leave some wrong-colored blox in the world, but that's all.